### PR TITLE
altered the shape of the discriminator so it pools over all feature d…

### DIFF
--- a/yolo_uda/configs/yolov3.cfg
+++ b/yolo_uda/configs/yolov3.cfg
@@ -3,8 +3,8 @@
 #batch=1
 #subdivisions=1
 # Training
-batch=16
-subdivisions=1
+# batch=4
+# subdivisions=1
 width=416
 height=416
 channels=3

--- a/yolo_uda/training/main.py
+++ b/yolo_uda/training/main.py
@@ -25,8 +25,10 @@ def main(args, hyperparams, run):
     discriminator = Discriminator(alpha=args.alpha).to(device)
     
     # create dataloaders
-    mini_batch_size = model.hyperparams['batch'] // model.hyperparams['subdivisions']
-    dataloader = _create_data_loader(
+    # mini_batch_size = model.hyperparams['batch'] // model.hyperparams['subdivisions']
+    mini_batch_size = hyperparams['batch_size']
+    
+    source_dataloader = _create_data_loader(
         os.path.dirname(args.train_path)+"/train.txt",
         batch_size=hyperparams['batch_size'],
         img_size=hyperparams['img_size'],
@@ -66,7 +68,7 @@ def main(args, hyperparams, run):
     model = train(
         model=model,
         discriminator=discriminator,
-        dataloader=dataloader,
+        source_dataloader=source_dataloader,
         device=device,
         optimizer=optimizer,
         optimizer_classifier=optimizer_classifier,
@@ -83,12 +85,12 @@ def main(args, hyperparams, run):
     )
 
     # save model weights
-    save_dir = os.path.join(args.save, f"{datetime.today().strftime('%Y-%m-%d')}_{run.id}.pth")
+    save_dir = os.path.join(args.save, f"{datetime.today().strftime('%Y-%m-%d')}.pth")
     torch.save(model.state_dict(), save_dir)
     best_model = wandb.Artifact(args.name, type="model")
     best_model.add_file(save_dir)
-    run.log_artifact(best_model)
-    run.link_artifact(best_model, "model-registry/yolo-uda")
+    # run.log_artifact(best_model)
+    # run.link_artifact(best_model, "model-registry/yolo-uda")
     
 if __name__ == '__main__':
     ap = argparse.ArgumentParser()
@@ -102,8 +104,8 @@ if __name__ == '__main__':
                     help="Path to file containing validation images")
     ap.add_argument("-c", "--config", required=True,
                     help="YOLOv3 configuration file")
-    ap.add_argument("-p", "--pretrained_weights", required=True,
-                    help="Path to pretrained weights")
+    ap.add_argument("-p", "--pretrained_weights",
+                    help="Path to pretrained weights", default=None)
     ap.add_argument("-e", "--epochs", type=int, default=300,
                     help="Number of training epochs")
     ap.add_argument("--n-cpu", type=int, default=6,

--- a/yolo_uda/training/models.py
+++ b/yolo_uda/training/models.py
@@ -47,8 +47,8 @@ def create_modules(module_defs: List[dict]) -> Tuple[dict, nn.ModuleList]:
     """
     hyperparams = module_defs.pop(0)
     hyperparams.update({
-        'batch': int(hyperparams['batch']),
-        'subdivisions': int(hyperparams['subdivisions']),
+        # 'batch': int(hyperparams['batch_size']),
+        # 'subdivisions': int(hyperparams['subdivisions']),
         'width': int(hyperparams['width']),
         'height': int(hyperparams['height']),
         'channels': int(hyperparams['channels']),
@@ -186,7 +186,7 @@ class Discriminator(nn.Module):
     A 3-layer MLP + Greadient Reversal Layer for domain classification.
     """
 
-    def __init__(self, in_size=52, h=2048, out_size=1, alpha=1.0):
+    def __init__(self, in_size=255*13*13, h=2048, out_size=1, alpha=1.0):
         """
         Arguments:
             in_size: size of the input
@@ -197,20 +197,22 @@ class Discriminator(nn.Module):
 
         super().__init__()
         self.h = h
+        # TODO: Consider adding Dropout layers after the ReLU layers
         self.net = nn.Sequential(
             GradientReversal(alpha=alpha),
             nn.Linear(in_size, h),
             nn.ReLU(),
             nn.Linear(h, h),
             nn.ReLU(),
-            nn.Linear(h, out_size)
+            nn.Linear(h, out_size),
+            nn.Sigmoid()
         )
         self.out_size = out_size
 
     def forward(self, x):
         """"""
         # return self.net(x).squeeze(1)
-        return self.net(x)
+        return self.net(torch.flatten(x,1)).squeeze(-1)
 
 #####################
 # YOLO architecture #

--- a/yolo_uda/training/trainer.py
+++ b/yolo_uda/training/trainer.py
@@ -13,7 +13,8 @@ from pytorchyolo.utils.utils import to_cpu, ap_per_class, get_batch_statistics, 
 from models import Upsample
 
 # for loss calculations
-cross_entropy = nn.CrossEntropyLoss()
+# cross_entropy = nn.CrossEntropyLoss()
+bce = nn.BCELoss()
 binary_accuracy = BinaryAccuracy(threshold=0.5).to('cuda')
 
 def print_eval_stats(metrics_output, class_names, verbose):
@@ -109,7 +110,8 @@ def discriminator_step(
     
     # calculate loss
     # outputs = outputs.view(mini_batch_size, -1)
-    discriminator_loss = cross_entropy(outputs, labels.float())
+    # discriminator_loss = cross_entropy(outputs, labels.float())
+    discriminator_loss = bce(outputs, labels.float())
     
     return discriminator_loss, discriminator_acc
 
@@ -239,7 +241,8 @@ def train(
                 "dscm_src_loss": float(discriminator_source_loss),
                 "dscm_trgt_loss": float(discriminator_target_loss),
                 "dscm_src_acc": float(discriminator_source_acc),
-                "dscm_trgt_acc": float(discriminator_target_acc)
+                "dscm_trgt_acc": float(discriminator_target_acc),
+                "dscm_acc": float(0.5*(discriminator_source_acc+discriminator_target_acc))
                 })
             model.seen += imgs_s.size(0)
             

--- a/yolo_uda/training/trainer.py
+++ b/yolo_uda/training/trainer.py
@@ -104,19 +104,19 @@ def discriminator_step(
     outputs = discriminator(map_features)
     
     # calculate accuracy
-    pred_labels = outputs[:, 0, 0, 0]
-    discriminator_acc = binary_accuracy(pred_labels, labels)
+    # pred_labels = outputs[:, 0, 0, 0]
+    discriminator_acc = binary_accuracy(outputs, labels)
     
     # calculate loss
-    outputs = outputs.view(mini_batch_size, -1)
-    discriminator_loss = cross_entropy(outputs, labels)
+    # outputs = outputs.view(mini_batch_size, -1)
+    discriminator_loss = cross_entropy(outputs, labels.float())
     
     return discriminator_loss, discriminator_acc
 
 def train(
     model: nn.Module,
     discriminator: nn.Module,
-    dataloader: DataLoader,
+    source_dataloader: DataLoader,
     device: torch.device,
     optimizer: torch.optim.Optimizer,
     optimizer_classifier: torch.optim.Optimizer,
@@ -131,8 +131,10 @@ def train(
     conf_thresh: float = 0.5,
     nms_thresh: float = 0.5,
 ):
-    upsample_4 = Upsample(scale_factor=4, mode="nearest")
-    upsample_2 = Upsample(scale_factor=2, mode="nearest")
+    # upsample_4 = Upsample(scale_factor=4, mode="nearest")
+    # upsample_2 = Upsample(scale_factor=2, mode="nearest")
+    downsample_2 = Upsample(scale_factor=0.5, mode="nearest")
+    downsample_4 = Upsample(scale_factor=0.25, mode="nearest")
     
     for epoch in range(1, epochs+1):
         
@@ -143,36 +145,47 @@ def train(
         discriminator.train() # set discriminator to training mode
 
         for batch_i, (data_source, data_target) in enumerate(
-            tqdm.tqdm(zip(dataloader, target_dataloader), desc=f"Training Epoch {epoch}")
+            tqdm.tqdm(zip(source_dataloader, target_dataloader), desc=f"Training Epoch {epoch}")
         ):
-            batches_done = len(dataloader) * epoch + batch_i
+            batches_done = len(source_dataloader) * (epoch-1) + batch_i
             
             # get imgs from data
-            _, imgs, targets = data_source
+            _, imgs_s, targets = data_source
             _, imgs_t, _ = data_target
-            if len(imgs) < mini_batch_size or len(imgs_t) < mini_batch_size:
+            if len(imgs_s) < mini_batch_size or len(imgs_t) < mini_batch_size:
                 break
-            source_imgs = imgs.to(device)
+            source_imgs = imgs_s.to(device)
             target_imgs = imgs_t.to(device)
             targets = targets.to(device)
             
             # run source pass, upsample features and calculate yolo loss
             source_outputs, source_features = model(source_imgs)
-            source_features[0] = upsample_4(source_features[0])
-            source_features[1] = upsample_2(source_features[1])
+            # source_features[0] = upsample_4(source_features[0])
+            # source_features[1] = upsample_2(source_features[1])
+            source_features[1] = downsample_2(source_features[1])
+            source_features[2] = downsample_4(source_features[2])
             yolo_loss, loss_components = compute_loss(source_outputs, targets, model)
             
             # run target pass upsample features
             zeros_label = torch.zeros(mini_batch_size, dtype=torch.long, device=device)
             ones_label = torch.ones(mini_batch_size, dtype=torch.long, device=device)
             target_outputs, target_features = model(target_imgs)
-            target_features[0] = upsample_4(target_features[0])
-            target_features[1] = upsample_2(target_features[1])
+            # target_features[0] = upsample_4(target_features[0])
+            # target_features[1] = upsample_2(target_features[1])
+            target_features[1] = downsample_2(target_features[1])
+            target_features[2] = downsample_4(target_features[2])
             
             # concatenate source and target features
-            source_features = torch.cat(source_features, dim=1).to(device)
-            target_features = torch.cat(target_features, dim=1).to(device)
-            
+            # source_features = torch.cat(source_features, dim=1).to(device)
+            # target_features = torch.cat(target_features, dim=1).to(device)
+            source_features = source_features[0]+source_features[1]+source_features[2]
+            target_features = target_features[0]+target_features[1]+target_features[2]
+
+            # Combine source and target batches for discriminator
+            # features = torch.cat([source_features,target_features],axis=0)
+            # labels = torch.cat([zeros_label,ones_label],axis=0)
+            # discriminator_loss, discriminator_acc = discriminator_step(discriminator, features, label, 2*mini_batch_size)
+
             # discriminator step and calculate discriminator loss
             discriminator_source_loss, discriminator_source_acc = discriminator_step(discriminator, source_features, zeros_label, mini_batch_size)
             discriminator_target_loss, discriminator_target_acc = discriminator_step(discriminator, target_features, ones_label, mini_batch_size)
@@ -183,27 +196,27 @@ def train(
             loss.backward()
 
             # run optimizer
-            if batches_done % model.hyperparams['subdivisions'] == 0:
-                # adapt learning rate
-                lr = model.hyperparams['learning_rate']
-                if batches_done < model.hyperparams['burn_in']:
-                    lr *= (batches_done / model.hyperparams['burn_in'])
-                else:
-                    for threshold, value in model.hyperparams['lr_steps']:
-                        if batches_done > threshold:
-                            lr *= value
-                # log the learning rate
-                # wandb.log({"lr": lr})
-                # set leraning rate
-                for g in optimizer.param_groups:
-                    g['lr'] = lr
-                    
-                # Run optimizer
-                optimizer.step()
-                optimizer_classifier.step()
-                # Reset gradients
-                optimizer.zero_grad()
-                optimizer_classifier.zero_grad()
+            # if batches_done % model.hyperparams['subdivisions'] == 0:
+            # adapt learning rate
+            lr = model.hyperparams['learning_rate']
+            if batches_done < model.hyperparams['burn_in']:
+                lr *= (batches_done / model.hyperparams['burn_in'])
+            else:
+                for threshold, value in model.hyperparams['lr_steps']:
+                    if batches_done > threshold:
+                        lr *= value
+            # log the learning rate
+            wandb.log({"lr": lr})
+            # set leraning rate
+            for g in optimizer.param_groups:
+                g['lr'] = lr
+                
+            # Run optimizer
+            optimizer.step()
+            optimizer_classifier.step()
+            # Reset gradients
+            optimizer.zero_grad()
+            optimizer_classifier.zero_grad()
         
             # log progress
             if verbose:
@@ -228,7 +241,7 @@ def train(
                 "dscm_src_acc": float(discriminator_source_acc),
                 "dscm_trgt_acc": float(discriminator_target_acc)
                 })
-            model.seen += imgs.size(0)
+            model.seen += imgs_s.size(0)
             
         # save model to checkpoint file
         # if epoch % args.checkpoint_interval == 0:


### PR DESCRIPTION
Made some changes to the Discriminator:

- The biggest change is that the `Linear(h,out_size)` last layer in `Discriminator` only aggregates the last dimension of the input. That's why you needed that `pred_labels = outputs[:,0,0,0]` line.  The standard way to handle this is to flatten the dimensions before the Linear layers.  I did this in the `Discriminator.forward()` method.
- I also 1) downsampled the feature layers instead of upsample. I also added them instead of stacking/concatenating them. Both changes are just to reduce the memory and parameter requirements. We can change them back if we need/want to later on a bigger machine. 

A few other things:
* Renamed "dataloader" to "source_dataloader" and similar other variables
* Removed `batch=16` and `subdivisions=1` from `yolov3.cfg` because they conflict with `batch_size` that's passed in `main`.
*  `subdivisions` we can add back, but I'm not sure what it does that's useful? 
*  We can define batch size in either place, but let's only do it once.
* Removed the `required=True` from pretrained-weights arg.  Not sure what to pass during the first training otherwise? 