### PR TITLE
Michael/yolo uda discriminator update

### DIFF
--- a/yolo_uda/training/main.py
+++ b/yolo_uda/training/main.py
@@ -60,7 +60,7 @@ def main(args, hyperparams, run):
     )
     optimizer_classifier = optim.Adam(
         params_classifier,
-        lr=0.001,
+        lr=0.0001,
         weight_decay=0.0001
     )
         

--- a/yolo_uda/training/main.py
+++ b/yolo_uda/training/main.py
@@ -75,6 +75,7 @@ def main(args, hyperparams, run):
         mini_batch_size=mini_batch_size,
         target_dataloader=target_dataloader,
         validation_dataloader=validation_dataloader,
+        lambda_discriminator=args.lambda_disc,
         verbose=args.verbose,
         epochs=args.epochs,
         evaluate_interval=args.eval_interval,
@@ -98,6 +99,8 @@ if __name__ == '__main__':
                     help="Number of target examples to add to training set")
     ap.add_argument("-a", "--alpha", type=float, required=True,
                     help="Constant for gradient reversal layer")
+    ap.add_argument("-l", "--lambda-disc", type=float, default=0.5,
+                    help="Weighting for discriminator loss, yolo weight is 1.0")
     ap.add_argument("-t", "--train-path", required=True,
                     help="Path to file containing training images")
     ap.add_argument("-v", "--val-path", required=True,

--- a/yolo_uda/training/models.py
+++ b/yolo_uda/training/models.py
@@ -199,7 +199,7 @@ class Discriminator(nn.Module):
         self.h = h
         # TODO: Consider adding Dropout layers after the ReLU layers
         self.net = nn.Sequential(
-            GradientReversal(alpha=alpha),
+            # GradientReversal(alpha=alpha),
             nn.Linear(in_size, h),
             nn.ReLU(),
             nn.Linear(h, h),

--- a/yolo_uda/training/models.py
+++ b/yolo_uda/training/models.py
@@ -198,7 +198,7 @@ class Discriminator(nn.Module):
         super().__init__()
 
         self.net = nn.Sequential(
-            # GradientReversal(alpha=alpha),
+            GradientReversal(alpha=alpha),
             nn.Linear(in_size, h),
             nn.ReLU(),
             nn.Linear(h, h),

--- a/yolo_uda/training/models.py
+++ b/yolo_uda/training/models.py
@@ -196,27 +196,18 @@ class Discriminator(nn.Module):
         """
 
         super().__init__()
-        h_2 = int(h/2)
-        h_3 = int(h/4)
-        h_4 = int(h/8)
 
         self.net = nn.Sequential(
             # GradientReversal(alpha=alpha),
             nn.Linear(in_size, h),
             nn.ReLU(),
-            nn.Linear(h, h_2),
+            nn.Linear(h, h),
             nn.ReLU(),
-            nn.Linear(h_2, h_3),
-            nn.ReLU(),
-            nn.Linear(h_3, h_4),
-            nn.ReLU(),
-            nn.Linear(h_4, out_size),
+            nn.Linear(h, out_size),
             nn.Sigmoid()
         )
 
     def forward(self, x):
-        """"""
-        # return self.net(x).squeeze(1)
         return self.net(torch.flatten(x,1)).squeeze(-1)
 
 #####################

--- a/yolo_uda/training/models.py
+++ b/yolo_uda/training/models.py
@@ -196,18 +196,23 @@ class Discriminator(nn.Module):
         """
 
         super().__init__()
-        self.h = h
-        # TODO: Consider adding Dropout layers after the ReLU layers
+        h_2 = int(h/2)
+        h_3 = int(h/4)
+        h_4 = int(h/8)
+
         self.net = nn.Sequential(
             # GradientReversal(alpha=alpha),
             nn.Linear(in_size, h),
             nn.ReLU(),
-            nn.Linear(h, h),
+            nn.Linear(h, h_2),
             nn.ReLU(),
-            nn.Linear(h, out_size),
+            nn.Linear(h_2, h_3),
+            nn.ReLU(),
+            nn.Linear(h_3, h_4),
+            nn.ReLU(),
+            nn.Linear(h_4, out_size),
             nn.Sigmoid()
         )
-        self.out_size = out_size
 
     def forward(self, x):
         """"""

--- a/yolo_uda/training/trainer.py
+++ b/yolo_uda/training/trainer.py
@@ -184,17 +184,18 @@ def train(
             target_features = target_features[0]+target_features[1]+target_features[2]
 
             # Combine source and target batches for discriminator
-            # features = torch.cat([source_features,target_features],axis=0)
-            # labels = torch.cat([zeros_label,ones_label],axis=0)
-            # discriminator_loss, discriminator_acc = discriminator_step(discriminator, features, label, 2*mini_batch_size)
+            features = torch.cat([source_features,target_features],axis=0)
+            labels = torch.cat([zeros_label,ones_label],axis=0)
+            discriminator_loss, discriminator_acc = discriminator_step(discriminator, features, labels, 2*mini_batch_size)
 
             # discriminator step and calculate discriminator loss
-            discriminator_source_loss, discriminator_source_acc = discriminator_step(discriminator, source_features, zeros_label, mini_batch_size)
-            discriminator_target_loss, discriminator_target_acc = discriminator_step(discriminator, target_features, ones_label, mini_batch_size)
-            discriminator_loss = discriminator_source_loss + discriminator_target_loss
+            # discriminator_source_loss, discriminator_source_acc = discriminator_step(discriminator, source_features, zeros_label, mini_batch_size)
+            # discriminator_target_loss, discriminator_target_acc = discriminator_step(discriminator, target_features, ones_label, mini_batch_size)
+            # discriminator_loss = discriminator_source_loss + discriminator_target_loss
 
             # run backward propagation
-            loss = yolo_loss + discriminator_loss
+            # loss = yolo_loss + discriminator_loss
+            loss = discriminator_loss
             loss.backward()
 
             # run optimizer
@@ -229,8 +230,8 @@ def train(
                             ["Object loss", float(loss_components[1])],
                             ["Class loss", float(loss_components[2])],
                             ["Loss", float(loss_components[3])],
-                            ["Source loss", float(discriminator_source_loss)],
-                            ["Target loss", float(discriminator_target_loss)],
+                            # ["Source loss", float(discriminator_source_loss)],
+                            # ["Target loss", float(discriminator_target_loss)],
                             ["YOLO Batch loss", to_cpu(yolo_loss).item()]
                         ]).table)
             wandb.log({
@@ -238,11 +239,12 @@ def train(
                 "obj_loss": float(loss_components[1]),
                 "cls_loss": float(loss_components[2]),
                 "yolo_loss": float(loss_components[3]),
-                "dscm_src_loss": float(discriminator_source_loss),
-                "dscm_trgt_loss": float(discriminator_target_loss),
-                "dscm_src_acc": float(discriminator_source_acc),
-                "dscm_trgt_acc": float(discriminator_target_acc),
-                "dscm_acc": float(0.5*(discriminator_source_acc+discriminator_target_acc))
+                # "dscm_src_loss": float(discriminator_source_loss),
+                # "dscm_trgt_loss": float(discriminator_target_loss),
+                # "dscm_src_acc": float(discriminator_source_acc),
+                # "dscm_trgt_acc": float(discriminator_target_acc),
+                "dscm_acc": float(discriminator_acc),
+                "dscm_loss": float(discriminator_loss)
                 })
             model.seen += imgs_s.size(0)
             

--- a/yolo_uda/training/trainer.py
+++ b/yolo_uda/training/trainer.py
@@ -155,6 +155,7 @@ def train(
     mini_batch_size: int,
     target_dataloader: DataLoader,
     validation_dataloader: DataLoader,
+    lambda_discriminator: float = 0.5,
     verbose: bool = False,
     epochs: int = 10,
     evaluate_interval: int = 1,
@@ -212,8 +213,7 @@ def train(
             discriminator_loss, discriminator_acc = discriminator_step(discriminator, features, labels, 2*mini_batch_size)
 
             # run backward propagation
-            # loss = yolo_loss + discriminator_loss
-            loss = discriminator_loss
+            loss = yolo_loss + lambda_discriminator * discriminator_loss
             loss.backward()
 
             # run optimizer


### PR DESCRIPTION
This PR makes a few changes to the discriminator code, which is now able to get ~100% accuracy between helios and BordenDay or BordenNight.
Changes:

- Reduced LR to 0.0001 (this was the key change)
- Moved `optimizer.zero_grad()` to the beginning of the loop as @amogh7joshi suggested 
- Added shuffling of the target and source samples in discriminator batches so it doesn't memorize which positions are always source or target.
- added lambda_discriminator param to weight the loss function
- Small refactoring here and there.

We have not tested the discriminator with a positive alpha in the GRL, which would be the expected way to use it.  The code should work, but we haven't tuned the loss weighting, learning rates, etc.