### PR TITLE
Michael/checkpoints and wandb step

### DIFF
--- a/yolo_uda/configs/yolov3-tiny.cfg
+++ b/yolo_uda/configs/yolov3-tiny.cfg
@@ -15,12 +15,12 @@ saturation = 1.5
 exposure = 1.5
 hue=.1
 
-learning_rate=0.0001
+learning_rate=5.0e-05
 burn_in=1000
 max_batches = 500200
 policy=steps
-steps=400000,450000
-scales=.1,.1
+steps=100000
+scales=.1
 
 # 0
 [convolutional]

--- a/yolo_uda/training/main.py
+++ b/yolo_uda/training/main.py
@@ -47,7 +47,7 @@ def main(args, hyperparams, run):
     validation_dataloader = _create_validation_data_loader(
         os.path.dirname(args.val_path)+"/val.txt",
         batch_size=1,
-        img_size=model.hyperparams['height'],
+        img_size=hyperparams['img_size'],
         n_cpu=args.n_cpu
     )
     

--- a/yolo_uda/training/main.py
+++ b/yolo_uda/training/main.py
@@ -65,8 +65,6 @@ def main(args, hyperparams, run):
         weight_decay=hyperparams["decay_disc"]
     )
 
-    
-
     # train
     model = train(
         model=model,
@@ -89,7 +87,8 @@ def main(args, hyperparams, run):
     )
 
     # save model weights
-    save_dir = os.path.join(args.save, f"{datetime.today().strftime('%Y-%m-%d')}.pth")
+    save_name = f"ckpt_last_k={args.k}_alpha={args.alpha}_lambda={args.lambda_disc}_{datetime.today().strftime('%Y-%m-%d_%H-%M-%S')}.pth"
+    save_dir = os.path.join(args.save, save_name)
     torch.save(model.state_dict(), save_dir)
     best_model = wandb.Artifact(args.name, type="model")
     best_model.add_file(save_dir)

--- a/yolo_uda/training/models.py
+++ b/yolo_uda/training/models.py
@@ -179,7 +179,7 @@ class _GradientReversal(torch.autograd.Function):
     def forward(ctx, input, alpha):
         wandb.log({
             "grl_forward_input_mean": input.mean().item(),
-        })
+        }, commit=False)
         ctx.alpha = alpha
         return input
 
@@ -187,7 +187,7 @@ class _GradientReversal(torch.autograd.Function):
     def backward(ctx, grad_output):
         wandb.log({
             "grl_backward_grad_mean": grad_output.mean().item(),
-        })
+        }, commit=False)
         return -ctx.alpha * grad_output, None
     
 class Discriminator(nn.Module):
@@ -297,6 +297,7 @@ class YOLOLayer(nn.Module):
         """
         yv, xv = torch.meshgrid([torch.arange(ny), torch.arange(nx)], indexing='ij')
         return torch.stack((xv, yv), 2).view((1, 1, ny, nx, 2)).float()
+
 
 class Darknet(nn.Module):
     """YOLOv3 object detection model"""

--- a/yolo_uda/training/models.py
+++ b/yolo_uda/training/models.py
@@ -12,6 +12,9 @@ from pytorch_metric_learning.utils import common_functions as pml_cf
 from pytorchyolo.utils.parse_config import parse_model_config
 from pytorchyolo.utils.utils import weights_init_normal
 
+import wandb
+
+
 def load_model(model_path, weights_path=None):
     """Loads the yolo model from file.
 
@@ -174,11 +177,17 @@ class GradientReversal(torch.nn.Module):
 class _GradientReversal(torch.autograd.Function):
     @staticmethod
     def forward(ctx, input, alpha):
+        wandb.log({
+            "grl_forward_input_mean": input.mean().item(),
+        })
         ctx.alpha = alpha
         return input
 
     @staticmethod
     def backward(ctx, grad_output):
+        wandb.log({
+            "grl_backward_grad_mean": grad_output.mean().item(),
+        })
         return -ctx.alpha * grad_output, None
     
 class Discriminator(nn.Module):

--- a/yolo_uda/training/trainer.py
+++ b/yolo_uda/training/trainer.py
@@ -115,7 +115,7 @@ def discriminator_step(
     
     return discriminator_loss, discriminator_acc
 
-def compose_discriminator_batch(source_features: torch.Tensor, target_features: torch.Tensor,
+def compose_discriminator_batch(batches_done: int, source_features: torch.Tensor, target_features: torch.Tensor,
                                 mini_batch_size: int, downsample_2: nn.Module, downsample_4: nn.Module,
                                 labels_source: torch.Tensor, labels_target: torch.Tensor,
                                 device: torch.device, shuffle: bool = True):
@@ -181,7 +181,7 @@ def train(
     # upsample_2 = Upsample(scale_factor=2, mode="nearest")
     downsample_2 = Upsample(scale_factor=0.5, mode="nearest")
     downsample_4 = Upsample(scale_factor=0.25, mode="nearest")
-    
+    batches_done = 0
 
     for epoch in range(1, epochs+1):
         print("\n---- Training Model ----")
@@ -214,8 +214,8 @@ def train(
             optimizer.zero_grad()
             optimizer_classifier.zero_grad()
 
-            batches_done = len(source_dataloader) * (epoch-1) + batch_i
-            
+            batches_done = len(target_dataloader) * (epoch-1) + batch_i
+
             # get imgs from data
             _, imgs_s, targets, labels_source = data_source
             _, imgs_t, _, labels_target = data_target
@@ -233,6 +233,7 @@ def train(
             yolo_loss, loss_components = compute_loss(source_outputs, targets, model)
             
             features, labels = compose_discriminator_batch(
+                batches_done=batches_done,
                 source_features=source_features, 
                 target_features=target_features, 
                 mini_batch_size=mini_batch_size, 

--- a/yolo_uda/training/trainer.py
+++ b/yolo_uda/training/trainer.py
@@ -176,8 +176,6 @@ def train(
     downsample_2 = Upsample(scale_factor=0.5, mode="nearest")
     downsample_4 = Upsample(scale_factor=0.25, mode="nearest")
     
-    # Control W&B step count
-    global_step = 0
 
     for epoch in range(1, epochs+1):
         
@@ -256,7 +254,7 @@ def train(
                     if batches_done > threshold:
                         lr *= value
             # log the learning rate
-            wandb.log({"lr": lr}, step=global_step)
+            wandb.log({"lr": lr}, step=batches_done)
             # set leraning rate
             for g in optimizer.param_groups:
                 g['lr'] = lr
@@ -299,19 +297,18 @@ def train(
                 # "dscm_acc": float(discriminator_acc),
                 "dscm_loss": float(discriminator_loss)
                 },
-                step=global_step)
+                step=batches_done)
             model.seen += imgs_s.size(0)
 
-            global_step += 1
 
         # Training epoch metrics
         # Discriminator accuracy
-        wandb.log({"dscm_acc": discriminator_acc["total"]/discriminator_acc["batch_count"]}, step=global_step)
+        wandb.log({"dscm_acc": discriminator_acc["total"]/discriminator_acc["batch_count"]}, step=batches_done)
         
         # Average cosine similarity within source, within target, and across source-target
         # For both feature layers
         for metric in [cosine_similarity_metrics_l15, cosine_similarity_metrics_l22, euclidean_distance_metrics_l15, euclidean_distance_metrics_l22]:
-            wandb.log(metric.return_metrics(), step=global_step)
+            wandb.log(metric.return_metrics(), step=batches_done)
             metric.reset()
         
         # save model to checkpoint file
@@ -344,6 +341,6 @@ def train(
                     "f1": f1.mean(),
                     "mAP": AP.mean()
                 },
-                step=global_step)
+                step=batches_done)
     
     return model

--- a/yolo_uda/training/trainer.py
+++ b/yolo_uda/training/trainer.py
@@ -115,7 +115,7 @@ def discriminator_step(
     
     return discriminator_loss, discriminator_acc
 
-def compose_discriminator_batch(batches_done: int, source_features: torch.Tensor, target_features: torch.Tensor,
+def compose_discriminator_batch(source_features: torch.Tensor, target_features: torch.Tensor,
                                 mini_batch_size: int, downsample_2: nn.Module, downsample_4: nn.Module,
                                 labels_source: torch.Tensor, labels_target: torch.Tensor,
                                 device: torch.device, shuffle: bool = True):
@@ -143,7 +143,7 @@ def compose_discriminator_batch(batches_done: int, source_features: torch.Tensor
         'features_mean': source_features.mean(),
         'features_max': source_features.max(),
         'features_min': source_features.min(),
-    }, step=batches_done)
+    }, commit=False)
 
     # Combine source and target batches for discriminator
     features = torch.cat([source_features, target_features],axis=0).to(device)
@@ -233,7 +233,6 @@ def train(
             yolo_loss, loss_components = compute_loss(source_outputs, targets, model)
             
             features, labels = compose_discriminator_batch(
-                batches_done=batches_done,
                 source_features=source_features, 
                 target_features=target_features, 
                 mini_batch_size=mini_batch_size, 

--- a/yolo_uda/training/trainer.py
+++ b/yolo_uda/training/trainer.py
@@ -143,8 +143,7 @@ def compose_discriminator_batch(source_features: torch.Tensor, target_features: 
         'features_mean': source_features.mean(),
         'features_max': source_features.max(),
         'features_min': source_features.min(),
-
-    })
+    }, step=batches_done)
 
     # Combine source and target batches for discriminator
     features = torch.cat([source_features, target_features],axis=0).to(device)
@@ -185,7 +184,7 @@ def train(
     
     for epoch in range(1, epochs+1):
         print("\n---- Training Model ----")
-        wandb.log({'epoch': epoch})
+        wandb.log({'epoch': epoch}, step=batches_done)
 
         # set to training mode
         model.train() # set yolo model to training mode

--- a/yolo_uda/training/trainer.py
+++ b/yolo_uda/training/trainer.py
@@ -122,6 +122,7 @@ def compose_discriminator_batch(source_features: torch.Tensor, target_features: 
     # source_features[0] = upsample_4(source_features[0])
     # source_features[1] = upsample_2(source_features[1])
     source_features[1] = downsample_2(source_features[1])
+
     # only used for yolov3.cfg, not yolov3-tiny.cfg
     if len(source_features) == 3:
         source_features[2] = downsample_4(source_features[2])
@@ -138,6 +139,12 @@ def compose_discriminator_batch(source_features: torch.Tensor, target_features: 
     # concatenate source and target features
     source_features = torch.stack(source_features).sum(axis=0)
     target_features = torch.stack(target_features).sum(axis=0)
+    wandb.log({
+        'features_mean': source_features.mean(),
+        'features_max': source_features.max(),
+        'features_min': source_features.min(),
+
+    })
 
     # Combine source and target batches for discriminator
     features = torch.cat([source_features, target_features],axis=0).to(device)
@@ -177,8 +184,8 @@ def train(
     downsample_4 = Upsample(scale_factor=0.25, mode="nearest")
     
     for epoch in range(1, epochs+1):
-        
         print("\n---- Training Model ----")
+        wandb.log({'epoch': epoch})
 
         # set to training mode
         model.train() # set yolo model to training mode


### PR DESCRIPTION
3 small changes:

- Extended the checkpoint naming so that multiple runs in the same day don't overwrite each other.
- Pass `batches_done` to `wandb.log(step=batches_done,...)`. If you don't pass step, wandb increments `global_step` with every call of `wandb.log` and we call that ~5 times per batch.  This will be more consistent even if we change metrics.
- Updated `yolov3-tiny.cfg` for Amogh's LR schedule