### PR TITLE
added compatibility for validate and train split of the target set

### DIFF
--- a/yolo_uda/training/loader.py
+++ b/yolo_uda/training/loader.py
@@ -8,48 +8,53 @@ from pytorchyolo.utils.utils import worker_seed_set
 
 from datasets import UDAListDataset
 
-def prepare_data(train_path, val_path, K=0, skip_preparation=False):
+def prepare_data(train_path, target_train_path, target_val_path, K=0, skip_preparation=False):
     if skip_preparation:
         print("Skipping file preparation")
         return
 
     # create list to store file paths
-    paths = [val_path, train_path]
+    paths = [target_train_path, target_val_path, train_path]
     train_paths = []
-    val_paths = []
+    target_train_paths = []
+    target_val_paths = []
 
     # create a list to track whether a sample is target/source
     sample_loc_train = []
-    sample_loc_val = []
+    sample_loc_target_train = []
+    sample_loc_target_val = []
 
     # loop through the files in the directory
-    for i in range(0,2):
+    for i in range(0,3):
         for filename in os.listdir(paths[i]):
             if filename.endswith('.jpg') or filename.endswith('.jpeg') or filename.endswith('.png'):
                 file_path = os.path.join(paths[i],filename)
                 if i == 0:
-                    val_paths.append(file_path)
-                    sample_loc_val.append(1)
+                    target_train_paths.append(file_path)
+                    sample_loc_target_train.append(1)
+                elif i == 1:
+                    target_val_paths.append(file_path)
+                    sample_loc_target_val.append(1)
                 else:
                     train_paths.append(file_path)
                     sample_loc_train.append(0)
     
     # add target examples if K > 0
     if K > 0:
-        sample = random.sample(range(0, len(val_paths)), K)
-        examples = [val_paths[i] for i in sample]
+        sample = random.sample(range(0, len(target_train_paths)), K)
+        examples = [target_train_paths[i] for i in sample]
         train_paths += examples
         sample_loc_train += [1] * K
 
     # write to txt file
     train_output = os.path.join(os.path.dirname(train_path), 'train.txt')
-    val_output = os.path.join(os.path.dirname(val_path), 'val.txt')
-
+    target_train_output = os.path.join(os.path.dirname(target_train_path), 'target_train.txt')
+    target_val_output = os.path.join(os.path.dirname(target_val_path), 'target_val.txt')
 
     for fname, sample_locs, paths in zip(
-            [train_output, val_output],
-            [sample_loc_train, sample_loc_val],
-            [train_paths, val_paths]):
+            [train_output, target_train_output, target_val_output],
+            [sample_loc_train, sample_loc_target_train, sample_loc_target_val],
+            [train_paths, target_train_paths, target_val_paths]):
         with open(fname, 'w') as file:
             for path, loc in zip(paths, sample_locs):
                 file.write(path + ' ' + str(loc) + '\n')

--- a/yolo_uda/training/main.py
+++ b/yolo_uda/training/main.py
@@ -130,7 +130,7 @@ if __name__ == '__main__':
     ap.add_argument("-t", "--train-path", required=True,
                     help="Path to file containing training images")
     ap.add_argument("-tt", "--target-train-path", required=True,
-                    help="Path to file containing target validation images")
+                    help="Path to file containing target training images")
     ap.add_argument("-tv", "--target-val-path", required=True,
                     help="Path to file containing target validation images")
     ap.add_argument("-c", "--config", required=True,

--- a/yolo_uda/training/main.py
+++ b/yolo_uda/training/main.py
@@ -23,7 +23,7 @@ def main(args, hyperparams, run):
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     
     # prepare data
-    prepare_data(args.train_path, args.val_path, args.k, args.skip_preparation)
+    prepare_data(args.train_path, args.target_train_path, args.target_val_path, args.k, args.skip_preparation)
     
     # load models
     model = load_model(args.config, args.pretrained_weights).to(device)
@@ -42,7 +42,7 @@ def main(args, hyperparams, run):
         multiscale_training=False
     )
     target_dataloader = _create_data_loader(
-        os.path.dirname(args.val_path)+"/val.txt",
+        os.path.dirname(args.target_train_path)+"/target_train.txt",
         batch_size=hyperparams['batch_size'],
         img_size=hyperparams['img_size'],
         n_cpu=args.n_cpu,
@@ -50,7 +50,7 @@ def main(args, hyperparams, run):
     )
     
     validation_dataloader = _create_validation_data_loader(
-        os.path.dirname(args.val_path)+"/val.txt",
+        os.path.dirname(args.target_val_path)+"/target_val.txt",
         batch_size=1,
         img_size=hyperparams['img_size'],
         n_cpu=args.n_cpu
@@ -129,8 +129,10 @@ if __name__ == '__main__':
                     help="Number of samples per batch.")
     ap.add_argument("-t", "--train-path", required=True,
                     help="Path to file containing training images")
-    ap.add_argument("-v", "--val-path", required=True,
-                    help="Path to file containing validation images")
+    ap.add_argument("-tt", "--target-train-path", required=True,
+                    help="Path to file containing target validation images")
+    ap.add_argument("-tv", "--target-val-path", required=True,
+                    help="Path to file containing target validation images")
     ap.add_argument("-c", "--config", required=True,
                     help="YOLOv3 configuration file")
     ap.add_argument("-p", "--pretrained_weights",


### PR DESCRIPTION
Summary:
- new args for val/train split of the target set
```
ap.add_argument("-tt", "--target-train-path", required=True,
                    help="Path to file containing target validation images")
ap.add_argument("-tv", "--target-val-path", required=True,
                    help="Path to file containing target validation images")
```
- in `prepare_data`: create two different text files, target_train.txt and target_val.txt, in their respective directories (instead of just one val.txt)
- draw k images from `target_train_paths`
```
f K > 0:
        sample = random.sample(range(0, len(target_train_paths)), K)
        examples = [target_train_paths[i] for i in sample]
        train_paths += examples
        sample_loc_train += [1] * K
```
