### PR TITLE
Michael/intermediate ckpts

### DIFF
--- a/yolo_uda/training/loader.py
+++ b/yolo_uda/training/loader.py
@@ -8,10 +8,30 @@ from pytorchyolo.utils.utils import worker_seed_set
 
 from datasets import UDAListDataset
 
+K_VAL_MAP = {
+    1:1,
+    4:1,
+    8:1,
+    12:2,
+    16:3,
+    24:6,
+    32:8,
+    40:10,
+    98:28,
+    58:15
+}
+
 def prepare_data(train_path, target_train_path, target_val_path, K=0, skip_preparation=False):
     if skip_preparation:
         print("Skipping file preparation")
         return
+
+    # K_val is determined by k per CropGAN paper.   
+    if K in K_VAL_MAP:
+        K_val = K_VAL_MAP[K]
+    else:
+        # For Gemini if we use a different k value than in paper.
+        K_val = max(1,int(0.25*K))
 
     # create list to store file paths
     paths = [target_train_path, target_val_path, train_path]
@@ -32,7 +52,7 @@ def prepare_data(train_path, target_train_path, target_val_path, K=0, skip_prepa
                 if i == 0:
                     target_train_paths.append(file_path)
                     sample_loc_target_train.append(1)
-                elif i == 1:
+                elif i == 1 and len(target_val_paths) < K_val:
                     target_val_paths.append(file_path)
                     sample_loc_target_val.append(1)
                 else:
@@ -50,7 +70,7 @@ def prepare_data(train_path, target_train_path, target_val_path, K=0, skip_prepa
     train_output = os.path.join(os.path.dirname(train_path), 'train.txt')
     target_train_output = os.path.join(os.path.dirname(target_train_path), 'target_train.txt')
     target_val_output = os.path.join(os.path.dirname(target_val_path), 'target_val.txt')
-
+    
     for fname, sample_locs, paths in zip(
             [train_output, target_train_output, target_val_output],
             [sample_loc_train, sample_loc_target_train, sample_loc_target_val],

--- a/yolo_uda/training/main.py
+++ b/yolo_uda/training/main.py
@@ -1,12 +1,14 @@
 import argparse
 import wandb
 import os
+import pathlib
+
 import torch
 import torch.optim as optim
-
 from PIL import Image
 from torchvision import transforms
 # from pytorchyolo.test import _create_validation_data_loader
+
 from loader import prepare_data, _create_data_loader, _create_validation_data_loader
 from models import load_model, Discriminator, Upsample
 from trainer import train
@@ -84,6 +86,11 @@ def main(args, hyperparams, run):
         
     else:
         # train
+        save_folder = f"k={args.k}_alpha={args.alpha}_lambda={args.lambda_disc}" 
+        save_dir = os.path.join(args.save,save_folder)
+        
+        pathlib.Path(save_dir).mkdir(parents=True, exist_ok=True) 
+        
         model = train(
             model=model,
             discriminator=discriminator,
@@ -97,17 +104,17 @@ def main(args, hyperparams, run):
             lambda_discriminator=args.lambda_disc,
             verbose=args.verbose,
             epochs=args.epochs,
-            evaluate_interval=args.eval_interval,
+            evaluate_interval=args.eval_interval,            
+            save_dir=save_dir,
             class_names=class_names,
             iou_thresh=hyperparams["iou_thresh"],
             conf_thresh=hyperparams["conf_thresh"],
             nms_thresh=hyperparams["nms_thresh"]
         )
-
         # save model weights
-        save_name = f"ckpt_last_k={args.k}_alpha={args.alpha}_lambda={args.lambda_disc}_{datetime.today().strftime('%Y-%m-%d_%H-%M-%S')}.pth"
-        save_dir = os.path.join(args.save, save_name)
-        torch.save(model.state_dict(), save_dir)
+        save_name = f"ckpt_last_{datetime.today().strftime('%Y-%m-%d_%H-%M-%S')}.pth"
+        save_filepath = os.path.join(save_dir, save_name)
+        torch.save(model.state_dict(), save_filepath)
         best_model = wandb.Artifact(args.name, type="model")
         best_model.add_file(save_dir)
         # run.log_artifact(best_model)
@@ -139,7 +146,7 @@ if __name__ == '__main__':
                     help="Number of training epochs")
     ap.add_argument("--n-cpu", type=int, default=6,
                     help="Number of cpu threads")
-    ap.add_argument("--eval_interval", type=int, default=1,
+    ap.add_argument("--eval_interval", type=int, default=50,
                     help="Evaluate model every eval_interval epochs")
     ap.add_argument("--eval-only", action="store_true",
                     help="Only runs validation with the provided model weights.")

--- a/yolo_uda/training/trainer.py
+++ b/yolo_uda/training/trainer.py
@@ -1,8 +1,10 @@
+import os
+from datetime import datetime
+
 import torch
 import tqdm
 import wandb
 import numpy as np
-
 from torch import nn
 import torch.nn.functional as F
 from terminaltables import AsciiTable
@@ -168,6 +170,7 @@ def train(
     mini_batch_size: int,
     target_dataloader: DataLoader,
     validation_dataloader: DataLoader,
+    save_dir: str,
     lambda_discriminator: float = 0.5,
     verbose: bool = False,
     epochs: int = 10,
@@ -365,5 +368,12 @@ def train(
                     "mAP": AP.mean()
                 },
                 step=batches_done)
+            
+            # Save checkpoint
+            # save model weights
+            save_name = f"ckpt_epoch_{epoch}_{datetime.today().strftime('%Y-%m-%d_%H-%M-%S')}.pth"
+            save_filepath = os.path.join(save_dir, save_name)
+            torch.save(model.state_dict(), save_filepath)
+            
     
     return model


### PR DESCRIPTION
Does 2 things:

- Limits validation set size to `k_val` (equivalent of `b` in CropGAN paper). This is handled automatically based on `k` since `k_val = 0.25 * k`
- Adds intermediate checkpointing. A checkpoint is saved at every `eval_interval` so I have increased `eval_interval` from 1 to 50 by default. Otherwise we'd save 1000 checkpoints per run.

These changes don't require any config changes!