### PR TITLE
calculate mmd at each epoch

### DIFF
--- a/yolo_uda/training/metrics.py
+++ b/yolo_uda/training/metrics.py
@@ -4,6 +4,8 @@ import math
 import torch
 import torch.nn.functional as F
 
+from torch import nn
+
 class FeatureMapMetric:
     def __init__(self, layer: str = "", device: str = "cuda"):
         self.layer = layer
@@ -79,3 +81,53 @@ class FeatureMapEuclideanDistance(FeatureMapMetric):
         self.metric_across += torch.Tensor(dist_across).mean()
         self.batch_count += 1
     
+### MMD Loss ###
+# Reference: https://github.com/yiftachbeer/mmd_loss_pytorch/blob/master/mmd_loss.py #
+class RBF(nn.Module):
+    def __init__(self, n_kernels=5, mul_factor=2.0, bandwidth=None, device='cuda'):
+        super().__init__()
+        self.bandwidth_multipliers = (mul_factor ** (torch.arange(n_kernels, device=device) - n_kernels // 2))
+        self.bandwidth = bandwidth
+
+    def get_bandwidth(self, L2_distances):
+        if self.bandwidth is None:
+            n_samples = L2_distances.shape[0]
+            return L2_distances.data.sum() / (n_samples ** 2 - n_samples)
+        return self.bandwidth
+
+    def forward(self, X):
+        L2_distances = torch.cdist(X, X) ** 2
+        return torch.exp(-L2_distances[None, ...] / (self.get_bandwidth(L2_distances) * self.bandwidth_multipliers)[:, None, None]).sum(dim=0)
+
+class MMDLoss(nn.Module):
+    def __init__(self, n_kernels=5, mul_factor=2.0, bandwidth=None, device="cuda"):
+        super().__init__()
+        self.kernel = RBF(n_kernels=n_kernels, mul_factor=mul_factor, bandwidth=bandwidth, device=device)
+        self.device = device
+        self.mmd_loss = torch.zeros(1, device=device)
+        self.batch_count = 0
+
+    def return_metrics(self):
+        return {
+            "mmd_loss": self.mmd_loss / self.batch_count
+        }
+
+    def reset(self):
+        self.mmd_loss = torch.zeros(1, device=self.device)
+        self.batch_count = 0
+
+    def forward(self, source_features, target_features):
+        source_flattened = source_features.view(source_features.size(0), -1).to(self.device)
+        target_flattened = target_features.view(target_features.size(0), -1).to(self.device)
+
+        K = self.kernel(torch.vstack([source_flattened, target_flattened]))
+
+        X_size = source_flattened.shape[0]
+
+        XX = K[:X_size, :X_size].mean()
+        YY = K[X_size:, X_size:].mean()
+        XY = K[:X_size, X_size:].mean()
+
+        mmd_loss = XX - 2 * XY + YY
+        self.mmd_loss += mmd_loss
+        self.batch_count += 1


### PR DESCRIPTION
Attempting to see if there is a metric that can quantify DA during training.

[Mean Maximum Discrepancy](https://jmlr.csail.mit.edu/papers/v13/gretton12a.html) is used to find the difference between two probability distributions, in our case: source and target. I've noticed it being used often in many DA papers so I thought I could try it.

It would be interesting to see how this value trends during training for both GEMINI and Grape tasks?
Sample runs: [Baseline](https://wandb.ai/paibl/yolo-uda/runs/vei6wieo) and [GRL](https://wandb.ai/paibl/yolo-uda/runs/x1pzr1w2) 

Main changes:
- Added MDDLoss calculation using RBF kernel
- takes an average per epoch (there might be a better approach for this?)
- Im using layer 22 for this calculation