### PR TITLE
Michael/add train label path

### DIFF
--- a/src/data/yolo_task_reverse_dataset.py
+++ b/src/data/yolo_task_reverse_dataset.py
@@ -127,7 +127,7 @@ class YoloTaskReverseDataset(BaseDataset):
             self.transform_A, self.transform_B  = get_transform(self.opt, img_size=A_img.size, grayscale=(self.input_nc == 1))
             
             # Preprocess for A
-            A_label_path = A_path.replace("train", "label").replace(".png", ".txt").replace(".jpg", ".txt")
+            A_label_path = A_path.replace("train", "label").replace(".png", ".txt").replace(".jpg", ".txt").replace(".jpeg", ".txt")
             boxes = np.loadtxt(A_label_path).reshape(-1, 5)
             boxes = get_valid_box(boxes)
             boxes = torch.from_numpy(boxes)
@@ -163,7 +163,7 @@ class YoloTaskReverseDataset(BaseDataset):
 
 
             # Preprocess for labeled B
-            B_label_path = labeled_B_path.replace(".png", ".txt").replace(".jpg", ".txt")
+            B_label_path = labeled_B_path.replace(".png", ".txt").replace(".jpg", ".txt").replace(".jpeg", ".txt")
             boxes = np.loadtxt(B_label_path).reshape(-1, 5)
             boxes = get_valid_box(boxes)
             boxes = torch.from_numpy(boxes)

--- a/src/generate_cropgan_images.py
+++ b/src/generate_cropgan_images.py
@@ -31,6 +31,8 @@ def tensor_to_image(tensor):
 
 # This is called at the end of train_cropgan.py
 def generate_images_from_source(opt: argparse.Namespace, model: DoubleTaskCycleGanModel, run: wandb.run):
+    if opt.image_path[-1] != "/":
+        opt.image_path +="/"
     synth_images = sorted(glob.glob(opt.image_path + "*.jpg"))  # deterministic for WandB
     print("Image path: ", opt.image_path)
     print("Number of synth input images: ", len(synth_images))

--- a/src/generate_cropgan_images.py
+++ b/src/generate_cropgan_images.py
@@ -44,7 +44,9 @@ def generate_images_from_source(opt: argparse.Namespace, model: DoubleTaskCycleG
             fake_img = model.netG_A(raw_img_tensor)
             fake_img_np = fake_img.detach().cpu().squeeze(0).permute([1, 2, 0]) * 0.5 + 0.5
             im = tensor_to_image(fake_img_np)
-            im.save(opt.out_path + img_path.split('/')[-1])
+            save_path = opt.out_path + img_path.split('/')[-1]
+            print("Saving at: ",save_path)
+            im.save(save_path)
 
             # log the synthetic & syn2real images to WandB
             if opt.log:

--- a/src/generate_cropgan_images.py
+++ b/src/generate_cropgan_images.py
@@ -49,6 +49,7 @@ def generate_images_from_source(opt: argparse.Namespace, model: DoubleTaskCycleG
             fake_img_np = fake_img.detach().cpu().squeeze(0).permute([1, 2, 0]) * 0.5 + 0.5
             im = tensor_to_image(fake_img_np)
             save_path = os.path.join(opt.out_path, opt.name, img_path.split('/')[-1])
+            os.makedirs(os.path.dirname(save_path),exist_ok=True)
             im.save(save_path)
 
             # log the synthetic & syn2real images to WandB

--- a/src/generate_cropgan_images.py
+++ b/src/generate_cropgan_images.py
@@ -35,7 +35,7 @@ def generate_images_from_source(opt: argparse.Namespace, model: DoubleTaskCycleG
         opt.image_path +="/"
     if opt.out_path[-1] != "/":
         opt.out_path +="/"
-    synth_images = sorted(glob.glob(opt.image_path + "*.jpg"))  # deterministic for WandB
+    synth_images = sorted([file for extension in ['*.jpg', '*.png', '*.jpeg'] for file in glob.glob(opt.image_path + extension)])
     print("Image path: ", opt.image_path)
     print("Number of synth input images: ", len(synth_images))
 

--- a/src/generate_cropgan_images.py
+++ b/src/generate_cropgan_images.py
@@ -33,6 +33,8 @@ def tensor_to_image(tensor):
 def generate_images_from_source(opt: argparse.Namespace, model: DoubleTaskCycleGanModel, run: wandb.run):
     if opt.image_path[-1] != "/":
         opt.image_path +="/"
+    if opt.out_path[-1] != "/":
+        opt.out_path +="/"
     synth_images = sorted(glob.glob(opt.image_path + "*.jpg"))  # deterministic for WandB
     print("Image path: ", opt.image_path)
     print("Number of synth input images: ", len(synth_images))

--- a/src/generate_cropgan_images.py
+++ b/src/generate_cropgan_images.py
@@ -1,3 +1,4 @@
+import argparse
 import glob
 import sys
 import os
@@ -12,20 +13,11 @@ gan_dir = os.path.abspath("../src/")
 sys.path.append(gan_dir)
 
 from models import create_model
+from models.double_task_cycle_gan_model import DoubleTaskCycleGanModel
 from options.image_gen_options import ImageGenOptions
 import util.util as utils
 
 import wandb
-
-
-# Setup Model
-opt = ImageGenOptions().parse()
-
-model = create_model(opt)      # create a model given opt.model and other options
-# Load pretrained model weights
-model.setup(opt)               # regular setup: load and print networks; create schedulers
-model.eval()
-
 
 # Load a synthetic (Domain A) image you want to transfer
 # Loop through all the synthetic images, generate realistic ones.
@@ -37,31 +29,26 @@ def tensor_to_image(tensor):
         tensor = tensor[0]
     return Image.fromarray(tensor)
 
+# This is called at the end of train_cropgan.py
+def generate_images_from_source(opt: argparse.Namespace, model: DoubleTaskCycleGanModel, run: wandb.run):
+    synth_images = sorted(glob.glob(opt.image_path + "*.jpg"))  # deterministic for WandB
+    print("Image path: ", opt.image_path)
+    print("Number of synth input images: ", len(synth_images))
 
-synth_images = sorted(glob.glob(opt.image_path + "*.jpg"))  # deterministic for WandB
-print("Image path: ", opt.image_path)
-print("Number of synth input images: ", len(synth_images))
+    # results
+    with torch.no_grad():
+        for img_path in synth_images:
+            print(f"Processing img: {img_path}")
+            raw_image = Image.open(img_path).convert('RGB')
+            raw_img_tensor, raw_img_np = utils.preprocess_images(raw_image, resize=[416,416])
+            fake_img = model.netG_A(raw_img_tensor)
+            fake_img_np = fake_img.detach().cpu().squeeze(0).permute([1, 2, 0]) * 0.5 + 0.5
+            im = tensor_to_image(fake_img_np)
+            im.save(opt.out_path + img_path.split('/')[-1])
 
-
-# logging
-if opt.log:
-    wandb.init(project="cropgan-results", name=opt.name, config=opt)
-
-
-# results
-with torch.no_grad():
-    for img_path in synth_images:
-        print(f"Processing img: {img_path}")
-        raw_image = Image.open(img_path).convert('RGB')
-        raw_img_tensor, raw_img_np = utils.preprocess_images(raw_image, resize=[416,416])
-        fake_img = model.netG_A(raw_img_tensor)
-        fake_img_np = fake_img.detach().cpu().squeeze(0).permute([1, 2, 0]) * 0.5 + 0.5
-        im = tensor_to_image(fake_img_np)
-        im.save(opt.out_path + img_path.split('/')[-1])
-
-        # log the synthetic & syn2real images to WandB
-        if opt.log:
-            print("logging image to WandB")
-            wandb.log({"synthetic": [wandb.Image(raw_image, caption="synthetic")],
-                       "syn2real": [wandb.Image(im, caption="syn2real")]})
+            # log the synthetic & syn2real images to WandB
+            if opt.log:
+                print("logging image to WandB")
+                run.log({"synthetic": [wandb.Image(raw_image, caption="synthetic")],
+                        "syn2real": [wandb.Image(im, caption="syn2real")]})
 

--- a/src/generate_cropgan_images.py
+++ b/src/generate_cropgan_images.py
@@ -48,8 +48,7 @@ def generate_images_from_source(opt: argparse.Namespace, model: DoubleTaskCycleG
             fake_img = model.netG_A(raw_img_tensor)
             fake_img_np = fake_img.detach().cpu().squeeze(0).permute([1, 2, 0]) * 0.5 + 0.5
             im = tensor_to_image(fake_img_np)
-            save_path = opt.out_path + img_path.split('/')[-1]
-            print("Saving at: ",save_path)
+            save_path = os.path.join(opt.out_path, opt.name, img_path.split('/')[-1])
             im.save(save_path)
 
             # log the synthetic & syn2real images to WandB

--- a/src/options/base_options.py
+++ b/src/options/base_options.py
@@ -58,7 +58,7 @@ class BaseOptions():
         parser.add_argument('--random_view', type=float, default=0, help='random zoom from min crop size up to random_view, set to >=1 to enable, will disbale loadsize resize ')
         parser.add_argument('--eval_model', required=False, help='direct path to checkpoint of model be used')
         parser.add_argument('--yolo_evaluate_folder', type=str, default='None', help='the path to evaluate image file (label is the same pattern name) ')
-        parser.add_argument('--yolo_a_weights', type=str, default='', help='the location of trained yolo a network weights')
+        parser.add_argument('--yolo_a_weights', type=str, default='', help='the location of trained yolo a network weights, not the specific folder')
         parser.add_argument('--yolo_b_weights', type=str, default='', help='the location of trained yolo b network weights')
         parser.add_argument('--task_model_def', type=str, default='./config/yolov3.cfg', help='the location of trained yolo network definition')
         parser.add_argument('--yolo_img_size', type=int, default=416, help='the size of yolo net input')
@@ -70,6 +70,7 @@ class BaseOptions():
         parser.add_argument('--reverse_task_k', type=int, default=0, help='the number of labeled images from B to use during cyclegan training.')
         parser.add_argument("--grl_alpha", type=float, default=0.1, help="grl alpha and lambda")
         parser.add_argument("--grl_lambda", type=float, default=0.1, help="grl alpha and lambda")
+        parser.add_argument("--grl_lmmd", type=float, default=0.0, help="grl lambda mmd")
         # Logging parameters
         parser.add_argument("--wandb_name", type=str, default="default-cropgan-run", help="Name of the wandb run")
 

--- a/src/options/image_gen_options.py
+++ b/src/options/image_gen_options.py
@@ -1,17 +1,16 @@
 from .base_options import BaseOptions
+from .train_options import TrainOptions
 
-
-class ImageGenOptions(BaseOptions):
+class ImageGenOptions(TrainOptions):
     """
     This class includes training options.
     It also includes shared options defined in BaseOptions.
     """
     def initialize(self, parser):
-        parser = BaseOptions.initialize(self, parser)
+        parser = TrainOptions.initialize(self, parser)
         parser.add_argument('--image_path', type=str, help='Where to read synthetic images.')
         parser.add_argument('--out_path', type=str, help='Where to write modified images.')
-        parser.add_argument('--phase', type=str, default='gen', help='train, val, test, etc')
         parser.add_argument('--log', action='store_true', default=False, help='Whether to log the output')
-        self.isTrain = False        
+        self.isTrain = True        
         
         return parser

--- a/src/run_gan_sweep_plus_image_gen.sh
+++ b/src/run_gan_sweep_plus_image_gen.sh
@@ -36,11 +36,8 @@ mkdir -p $checkpoints_dir
 source_image_path="$dataroot/yolo_grl_data/BordenDay/source/train/images/"
 
 ## For Image Generation
-# Inside of checkpoints_dir, this is the specific directory for the run you want to use
-run_name="BASELINE_k_24_day"
-
 # Where you want the CropGAN generated images to go
-out_path="$dataroot/yolo_grl_data/BordenDay/cropgan_generated/$run_name"
+out_path="$dataroot/yolo_grl_data/BordenDay/cropgan_generated"
 
 # Weights used for yolo_a and yolo_b
 yolo_a_weights="$dataroot/yolo_grl_data/weights"
@@ -70,5 +67,5 @@ read -r -d '' standard_args << EOM
 --out_path $out_path
 EOM
 
-python -u train_cropgan.py --name $run_name --reverse_task_k 32 --wandb_name $run_name --grl_alpha 0.0 --grl_lambda 0.0 --grl_lmmd 0.0 $standard_args
-python -u train_cropgan.py --name $run_name --reverse_task_k 32 --wandb_name $run_name --grl_alpha 0.1 --grl_lambda 0.0001 --grl_lmmd 0.0005 $standard_args
+python -u train_cropgan.py --name BASELINE_k_32_day --reverse_task_k 32 --wandb_name $run_name --grl_alpha 0.0 --grl_lambda 0.0 --grl_lmmd 0.0 $standard_args
+python -u train_cropgan.py --name BEST_k_32_day --reverse_task_k 32 --wandb_name $run_name --grl_alpha 0.1 --grl_lambda 0.0001 --grl_lmmd 0.0005 $standard_args

--- a/src/run_gan_sweep_plus_image_gen.sh
+++ b/src/run_gan_sweep_plus_image_gen.sh
@@ -33,7 +33,7 @@ checkpoints_dir="$cropgan_dir/model_checkpoints/cyclegan/"
 mkdir -p $checkpoints_dir
 
 # Same as the training images for training yolo-uda: something like BordenNight/source/train/images
-source_image_path="$dataroot/yolo_grl_data/BordenDay/source/train/images"
+source_image_path="$dataroot/yolo_grl_data/BordenDay/source/train/images/"
 
 ## For Image Generation
 # Inside of checkpoints_dir, this is the specific directory for the run you want to use

--- a/src/run_gan_sweep_plus_image_gen.sh
+++ b/src/run_gan_sweep_plus_image_gen.sh
@@ -1,0 +1,74 @@
+#! /bin/bash -l
+#SBATCH --job-name=paibl
+#SBATCH --output=train.out
+#SBATCH --partition=gpum
+#SBATCH --nodes=1 
+#SBATCH --gpus-per-node=1
+#SBATCH --mail-user=michael.hamer.stanley@gmail.com
+#SBATCH --time=48:00:00 # Change the time accordingly
+#SBATCH --mail-type=ALL
+#SBATCH --error=train.err
+#SBATCH --cpus-per-task=12
+
+# Load module and load environment
+source ~/.bashrc
+conda activate yolo-uda
+unset PYTHONPATH
+WORKDIR="/group/jmearlesgrp/scratch/mhstan/CropGAN/src"
+cd $WORKDIR
+
+cropgan_dir="/group/jmearlesgrp/scratch/mhstan"
+dataroot="/group/jmearlesgrp/intermediate_data/mhstan"
+
+## For CropGAN
+# Source for CropGAN images (note: different structure than yolo source: trainA, labeledB, etc.)
+cropgan_source_images="$dataroot/syntheticVis2bordenDayRow"
+
+# Yolo Config
+task_model_def="$cropgan_dir/CropGAN/yolo_uda/configs/yolov3-tiny-lowlr.cfg"
+
+# Where the model checkpoints are saved
+checkpoints_dir="$cropgan_dir/model_checkpoints/cyclegan/"
+# make directories
+mkdir -p $checkpoints_dir
+
+# Same as the training images for training yolo-uda: something like BordenNight/source/train/images
+source_image_path="$dataroot/yolo_grl_data/BordenDay/source/train/images"
+
+## For Image Generation
+# Inside of checkpoints_dir, this is the specific directory for the run you want to use
+run_name="BASELINE_k_24_day"
+
+# Where you want the CropGAN generated images to go
+out_path="$dataroot/yolo_grl_data/BordenDay/cropgan_generated/$run_name"
+
+# Weights used for yolo_a and yolo_b
+yolo_a_weights="$dataroot/yolo_grl_data/weights"
+
+# standard arguments
+read -r -d '' standard_args << EOM
+--dataroot $cropgan_source_images \
+--num_threads 4 \
+--dataset_mode yolo_task_reverse \
+--checkpoints_dir $checkpoints_dir \
+--no_flip \
+--preprocess aug \
+--model double_task_cycle_gan \
+--load_size 416 \
+--crop_size 256 \
+--lambda_yolo_b 0.1 \
+--lambda_yolo_a 0.01 \
+--batch_size 1 \
+--cycle_gan_epoch 1 \
+--yolo_eval_on_real_period 500 \
+--yolo_epochs 0 \
+--task_model_def $task_model_def \
+--yolo_a_weights /group/jmearlesgrp/intermediate_data/mhstan/yolo_grl_data/weights \
+--save_epoch_freq 25 \
+--use_grl
+--image_path $source_image_path
+--out_path $out_path
+EOM
+
+python -u train_cropgan.py --name $run_name --reverse_task_k 32 --wandb_name $run_name --grl_alpha 0.0 --grl_lambda 0.0 --grl_lmmd 0.0 $standard_args
+python -u train_cropgan.py --name $run_name --reverse_task_k 32 --wandb_name $run_name --grl_alpha 0.1 --grl_lambda 0.0001 --grl_lmmd 0.0005 $standard_args

--- a/src/run_gan_sweep_plus_image_gen.sh
+++ b/src/run_gan_sweep_plus_image_gen.sh
@@ -67,5 +67,5 @@ read -r -d '' standard_args << EOM
 --out_path $out_path
 EOM
 
-python -u train_cropgan.py --name BASELINE_k_32_day --reverse_task_k 32 --wandb_name $run_name --grl_alpha 0.0 --grl_lambda 0.0 --grl_lmmd 0.0 $standard_args
-python -u train_cropgan.py --name BEST_k_32_day --reverse_task_k 32 --wandb_name $run_name --grl_alpha 0.1 --grl_lambda 0.0001 --grl_lmmd 0.0005 $standard_args
+python -u train_cropgan.py --name BASELINE_k_32_day --reverse_task_k 32 --wandb_name BASELINE_k_32_day --grl_alpha 0.0 --grl_lambda 0.0 --grl_lmmd 0.0 $standard_args
+python -u train_cropgan.py --name BEST_k_32_day --reverse_task_k 32 --wandb_name BEST_k_32_day --grl_alpha 0.1 --grl_lambda 0.0001 --grl_lmmd 0.0005 $standard_args

--- a/src/train_cropgan.py
+++ b/src/train_cropgan.py
@@ -41,7 +41,8 @@ if __name__ == '__main__':
     # speed up life
     # (auto-detect checkpoint location based on the given alpha/lambda, and search
     #  within the respective folder for the latest `ckpt_last_*.pth` model file).
-    opt.yolo_b_weights = opt.yolo_a_weights
+    if opt.yolo_b_weights == '':
+        opt.yolo_b_weights = opt.yolo_a_weights
     if os.path.isdir(opt.yolo_a_weights):
         possible_weight_path = os.path.join(
             opt.yolo_a_weights, f"k-{opt.reverse_task_k}_alpha-{opt.grl_alpha}_lambda-{opt.grl_lambda}_lmmd-{opt.grl_lmmd}", "ckpt_best_map.pth")

--- a/yolo_uda/training/datasets.py
+++ b/yolo_uda/training/datasets.py
@@ -56,7 +56,7 @@ class UDAImageFolder(Dataset):
 
 
 class UDAListDataset(Dataset):
-    def __init__(self, list_path, img_size=416, multiscale=True, transform=None):
+    def __init__(self, list_path, label_path=None, img_size=416, multiscale=True, transform=None):
         with open(list_path, "r") as file:
             self.label_nums = []
             self.img_files = []
@@ -71,7 +71,10 @@ class UDAListDataset(Dataset):
         self.label_files = []
         for path in self.img_files:
             image_dir = os.path.dirname(path)
-            label_dir = "labels".join(image_dir.rsplit("images", 1))
+            if label_path:
+                label_dir = label_path
+            else:
+                label_dir = "labels".join(image_dir.rsplit("images", 1))
             assert label_dir != image_dir, \
                 f"Image path must contain a folder named 'images'! \n'{image_dir}'"
             label_file = os.path.join(label_dir, os.path.basename(path))

--- a/yolo_uda/training/datasets.py
+++ b/yolo_uda/training/datasets.py
@@ -69,9 +69,9 @@ class UDAListDataset(Dataset):
                 self.label_nums.append(int(line.split()[1]))
 
         self.label_files = []
-        for path in self.img_files:
+        for img_idx, path in enumerate(self.img_files):
             image_dir = os.path.dirname(path)
-            if label_path:
+            if label_path and self.label_nums[img_idx] == 0:
                 label_dir = label_path
             else:
                 label_dir = "labels".join(image_dir.rsplit("images", 1))

--- a/yolo_uda/training/loader.py
+++ b/yolo_uda/training/loader.py
@@ -86,7 +86,7 @@ def prepare_data(train_path, target_train_path, target_val_path, K=0, skip_prepa
             print(f"File paths have been saved to {fname}")
 
         
-def _create_data_loader(img_path, batch_size, img_size, n_cpu, multiscale_training=False):
+def _create_data_loader(img_path, batch_size, img_size, n_cpu, label_path=None, multiscale_training=False):
     """Creates a DataLoader for training.
 
     :param img_path: Path to file containing all paths to training images.
@@ -104,6 +104,7 @@ def _create_data_loader(img_path, batch_size, img_size, n_cpu, multiscale_traini
     """
     dataset = UDAListDataset(
         img_path,
+        label_path=label_path,
         img_size=img_size,
         multiscale=multiscale_training,
         transform=AUGMENTATION_TRANSFORMS)
@@ -119,7 +120,7 @@ def _create_data_loader(img_path, batch_size, img_size, n_cpu, multiscale_traini
     return dataloader
 
 
-def _create_validation_data_loader(img_path, batch_size, img_size, n_cpu):
+def _create_validation_data_loader(img_path, batch_size, img_size, n_cpu, label_path=None):
     """
     Creates a DataLoader for validation.
 
@@ -134,7 +135,12 @@ def _create_validation_data_loader(img_path, batch_size, img_size, n_cpu):
     :return: Returns DataLoader
     :rtype: DataLoader
     """
-    dataset = UDAListDataset(img_path, img_size=img_size, multiscale=False, transform=DEFAULT_TRANSFORMS)
+    dataset = UDAListDataset(
+        img_path, 
+        label_path=label_path, 
+        img_size=img_size, 
+        multiscale=False, 
+        transform=DEFAULT_TRANSFORMS)
     dataloader = DataLoader(
         dataset,
         batch_size=batch_size,

--- a/yolo_uda/training/main.py
+++ b/yolo_uda/training/main.py
@@ -38,6 +38,7 @@ def main(args, hyperparams, run):
     
     source_dataloader = _create_data_loader(
         os.path.dirname(args.train_path)+f"/train_k_{args.k}.txt",
+        label_path=args.train_label_path,
         batch_size=hyperparams['batch_size'],
         img_size=hyperparams['img_size'],
         n_cpu=args.n_cpu,
@@ -135,6 +136,8 @@ if __name__ == '__main__':
                     help="Number of samples per batch.")
     ap.add_argument("-t", "--train-path", required=True,
                     help="Path to file containing training images")
+    ap.add_argument("--train-label-path", default=None,
+                    help="If labels are not in same directory as images, pass label path here")
     ap.add_argument("-tt", "--target-train-path", required=True,
                     help="Path to file containing target training images")
     ap.add_argument("-tv", "--target-val-path", required=True,


### PR DESCRIPTION
Adds `--train-label-path` which can point to the label directory (should end in `labels`) so that we don't have to copy the images into each folder of CropGAN-generated training images.

`--train-label-path` defaults to None and everything works as previously (`labels` is assumed to be in the same dir as `images`)