### PR TITLE
Focal Loss

### DIFF
--- a/yolo_uda/training/main.py
+++ b/yolo_uda/training/main.py
@@ -103,7 +103,7 @@ def main(args, hyperparams, run):
         # cross_entropy = nn.CrossEntropyLoss()
         if args.disc_loss_func == "focal":
             disc_loss_func = partial(sigmoid_focal_loss, alpha=-1, gamma=3, reduction='mean') 
-        elif args.disc_loss_func == "focal":
+        elif args.disc_loss_func == "bce":
             disc_loss_func = torch.nn.BCELoss()
         else:
             raise ValueError(f"disc loss func can only be bce or focal, received {args.disc_loss_func}.")

--- a/yolo_uda/training/trainer.py
+++ b/yolo_uda/training/trainer.py
@@ -11,6 +11,7 @@ from terminaltables import AsciiTable
 from torch.utils.data import DataLoader
 from torch.autograd import Variable
 from torchmetrics.classification import BinaryAccuracy
+from torchvision.ops import sigmoid_focal_loss
 from pytorchyolo.utils.loss import compute_loss
 from pytorchyolo.utils.utils import to_cpu, ap_per_class, get_batch_statistics, non_max_suppression, xywh2xyxy
 from models import Upsample
@@ -19,7 +20,8 @@ from metrics import FeatureMapCosineSimilarity, FeatureMapEuclideanDistance, MMD
 
 # for loss calculations
 # cross_entropy = nn.CrossEntropyLoss()
-bce = nn.BCELoss()
+# bce = nn.BCELoss()
+global_disc_loss = sigmoid_focal_loss(alpha=-1, gamma=3, reduction='mean')
 binary_accuracy = BinaryAccuracy(threshold=0.5).to('cuda')
 
 def print_eval_stats(metrics_output, class_names, verbose):
@@ -114,7 +116,7 @@ def discriminator_step(
     
     # calculate loss
     # discriminator_loss = cross_entropy(outputs, labels.float())
-    discriminator_loss = bce(outputs, labels.float())
+    discriminator_loss = global_disc_loss(outputs, labels.float())
     
     return discriminator_loss, discriminator_acc
 

--- a/yolo_uda/training/validate.py
+++ b/yolo_uda/training/validate.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Callable, Union
 import torch
 import tqdm
 import wandb
@@ -101,6 +101,7 @@ def validate(
     verbose: Optional[bool] = False,
     epochs: Optional[int] = 10,
     evaluate_interval: Optional[int] = 1,
+    discriminator_loss_function: Union[Callable, nn.Module] = None
 ):
     
     print("\n---- Evaluating Model ----")


### PR DESCRIPTION
Note: will rebase the PR on `yolo-uda` once PR #30 is merged.

This PR adds focal loss for the discriminator, and a flag to choose between focal loss and BCE loss.  The default values come from the [Weak-Strong Alignment](https://arxiv.org/pdf/1812.04798.pdf) paper, notably `gamma=3` (torchvision default is `gamma=2`).